### PR TITLE
delete old download folders

### DIFF
--- a/mcserver/zipsession.py
+++ b/mcserver/zipsession.py
@@ -7,6 +7,7 @@ import pickle
 import glob
 import zipfile
 import platform
+import time
 from decouple import config
 
 API_TOKEN = config("API_TOKEN")
@@ -398,9 +399,24 @@ def downloadAndZipSession(session_id,deleteFolderWhenZipped=True,isDocker=True,
     session = requests.get(host + "/sessions/{}/".format(session_id),
                          headers = {"Authorization": "Token {}".format(API_TOKEN)}).json()
     session_name = 'OpenCapData_' + session_id
-    session_path = os.path.join(data_dir,'Data',session_name)
+    baseDir = os.path.join(data_dir,'Data')
+    session_path = os.path.join(baseDir,session_name)
     
-    
+    # Look for old folders in this directory and delete them
+    if os.path.isdir(baseDir):
+        folders = os.listdir(baseDir) 
+        timeSinceModified = [(-os.path.getmtime(os.path.join(baseDir,f)) +int(time.time()))/60 for f in folders]
+        
+        for i,f in enumerate(folders):
+            if timeSinceModified[i] > 15: # delete if older than 15 mins
+                try:
+                    os.remove(os.path.join(baseDir,f)) # files
+                except:
+                    try:
+                        shutil.rmtree(os.path.join(baseDir,f)) # folders
+                    except:
+                        pass
+        
     calib_id = getCalibrationTrialID(session_id, host=host)
     neutral_id = getNeutralTrialID(session_id, host=host)
     dynamic_ids = [t['id'] for t in session['trials'] if (t['name'] != 'calibration' and t['name'] !='neutral')]


### PR DESCRIPTION
deletes zipped folders from API if more than 15 mins old.

Tested on dev as far as I could, but download does not work there.