### PR TITLE
Worker type

### DIFF
--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -633,6 +633,8 @@ class TrialViewSet(viewsets.ModelViewSet):
     def dequeue(self, request):
         ip = get_client_ip(request)
 
+        workerType = self.request.query_params.get('workerType')
+
         # find trials with some videos not uploaded
         not_uploaded = Video.objects.filter(video='',
                                             updated_at__gte=datetime.now().date() + timedelta(minutes=-15)).values_list("trial__id", flat=True)
@@ -647,10 +649,10 @@ class TrialViewSet(viewsets.ModelViewSet):
                                       name__in=["calibration","neutral"],
                                       result=None)
         
-        if trials.count() == 0:
+        if trials.count() == 0 and workerType != 'calibration':
             trials = uploaded_trials.filter(status="stopped",
                                       result=None)
-
+        
         if trials.count() == 0:
             raise Http404
 


### PR DESCRIPTION
the dequeue request now takes a query string that specifies what kind of trials it wants to receive. 
`https://api.opencap.ai/trials/dequeue/?workerString=all`

if workerType=all -> send back any job (still prioritizing calib, neutral)
if workerType=calibration -> only send back neutral and calib trials
if you don't add the `workerType` parameter, it defaults to all

I tested this on dev and it responds as expected.


