### PR TITLE
Better errors

### DIFF
--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -459,7 +459,7 @@ class SessionViewSet(viewsets.ModelViewSet):
                 res["session"] = SessionSerializer(session, many=False).data
 
         except NotAuthenticated:
-            raise NotFound('Sorry, you have to log in to access to this session.')
+            raise NotFound('Sorry, you have to log in to access this session.')
         except PermissionDenied:
             raise NotFound('Sorry, you don\'t have the permissions required to access this session.')
         except Http404:
@@ -467,7 +467,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         except ValueError:
             raise NotFound('Sorry, the UUID of the session with UUID: ' + pk + " is not valid")
         except Exception:
-            raise APIException("There was an error while recoding the trial. Please try again.")
+            raise APIException("There was an error while recording the trial. Please try again.")
 
         return res
 
@@ -541,7 +541,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         except ValueError:
             raise NotFound('Sorry, the UUID of the session with UUID: ' + pk + " is not valid")
         except Exception:
-            raise APIException("There was an error while recoding the trial. Please try again.")
+            raise APIException("There was an error while recording the trial. Please try again.")
 
         return Response(serializer.data)
 
@@ -581,7 +581,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         except ValueError:
             raise NotFound('Sorry, the UUID of the session with UUID: ' + pk + " is not valid")
         except Exception:
-            raise APIException("There was an error while getting the session's settings. Please try again.")
+            raise APIException("There was an error while getting the settings of the session. Please try again.")
 
         return Response(sessionPermission)
 
@@ -625,7 +625,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         except ValueError:
             raise NotFound('Sorry, the UUID of the session with UUID: ' + pk + " is not valid")
         except Exception:
-            raise APIException("There was an error while getting the session's settings. Please try again.")
+            raise APIException("There was an error while getting the settings of the session. Please try again.")
 
         return Response(settings_dict)
 
@@ -1306,7 +1306,7 @@ class NewPasswordView(APIView):
                 for object in objects:
                     object.delete()
 
-                raise NotFound("The link to reset your password has expired or does not exist. Try reset your password again.")
+                raise NotFound("The link to reset your password has expired or does not exist. Try resetting your password again.")
 
             else:
                 # If token exists, and it has not expired, set new password.
@@ -1318,7 +1318,7 @@ class NewPasswordView(APIView):
                 for object in objects:
                     object.delete()
         except Http404:
-            raise NotFound("The link to reset your password has expired. Try reset your password again.")
+            raise NotFound("The link to reset your password has expired. Try resetting your password again.")
         except Exception:
             raise APIException('There was an error while creating your new password. Please, try again.')
 

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -1,8 +1,41 @@
-from django.http import HttpResponse
-from django.http import Http404
+import os
+import sys
+import json
+import time
+import uuid
+import boto3
+import qrcode
+import platform
 
-from django.shortcuts import get_object_or_404, render
+from datetime import datetime, timedelta
+
+from django.views.decorators.csrf import csrf_exempt
+from django.template.loader import render_to_string
+from django.core.files.base import ContentFile
+from django.shortcuts import get_object_or_404
+from django.core.mail import EmailMessage
+from django.contrib.auth import login
+from django.http import FileResponse
+from django.db.models import Count
+from django.utils import timezone
+from django.conf import settings
+from django.http import Http404
+from django.db.models import Q
+
+
+from rest_framework import viewsets, permissions, status
+from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
+from rest_framework.decorators import api_view, renderer_classes
+from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.authtoken.models import Token
+from rest_framework.permissions import AllowAny
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+from rest_framework.views import APIView
+
 from mcserver.models import Session, User, Trial, Video, Result, ResetPassword, Subject
+from mcserver.zipsession import downloadAndZipSession, downloadAndZipSubject
 from mcserver.serializers import (
     SessionSerializer, TrialSerializer,
     VideoSerializer, ResultSerializer,
@@ -11,78 +44,37 @@ from mcserver.serializers import (
     UserSerializer,
     ResetPasswordSerializer,
     NewPasswordSerializer)
-from django.core.files.base import ContentFile
-from django.conf import settings
-from django.db.models import Q
-from django.utils import timezone
 
-from rest_framework.decorators import action, permission_classes
-from rest_framework.response import Response
-from rest_framework.reverse import reverse
-from rest_framework.views import APIView
-from rest_framework.authtoken.models import Token
-from rest_framework import status
-from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.authtoken.models import Token
-from rest_framework.permissions import AllowAny
+# from utils import switchCalibrationForCamera
 
-import qrcode
-import json
-import time
-import platform
+sys.path.insert(0, '/code/mobilecap')
 
-from rest_framework import viewsets
-from decouple import config
-
-import os
-import zipfile
-
-from django.http import FileResponse
-
-from django.db.models import Count
-
-from mcserver.zipsession import downloadAndZipSession, downloadAndZipSubject
-
-from datetime import datetime, timedelta
-
-import sys
-sys.path.insert(0,'/code/mobilecap')
-
-from rest_framework import exceptions
-from rest_framework.permissions import IsAuthenticated, AllowAny, DjangoModelPermissions
-
-from rest_framework import permissions
-
-from django.contrib.auth import authenticate, login
-import logging
-
-import boto3
-import requests
-
-import uuid
 
 class IsOwner(permissions.BasePermission):
     def has_permission(self, request, view):
         if not request.user.is_authenticated:
             return False
         return request.user.otp_verified
-    
+
     def has_object_permission(self, request, view, obj):
         return obj.get_user() == request.user
+
 
 class IsAdmin(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user.groups.filter(name='admin').exists()
-        
+
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)
+
 
 class IsBackend(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user.groups.filter(name='backend').exists()
-        
+
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)
+
 
 class IsPublic(permissions.BasePermission):
     def has_permission(self, request, view):
@@ -91,6 +83,7 @@ class IsPublic(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         return obj.is_public()
 
+
 class AllowPublicCreate(permissions.BasePermission):
     def has_permission(self, request, view):
         # create new or update existing video 
@@ -98,6 +91,7 @@ class AllowPublicCreate(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         return self.has_permission(request, view)
+
 
 def setup_eager_loading(get_queryset):
     def decorator(self):
@@ -108,8 +102,6 @@ def setup_eager_loading(get_queryset):
     return decorator
 
 
-#from utils import switchCalibrationForCamera
-
 def get_client_ip(request):
     x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
     if x_forwarded_for:
@@ -118,19 +110,19 @@ def get_client_ip(request):
         ip = request.META.get('REMOTE_ADDR')
     return ip
 
+
 def zipdir(path, ziph):
     # ziph is zipfile handle
     for root, dirs, files in os.walk(path):
         for file in files:
-            ziph.write(os.path.join(root, file), 
-                       os.path.relpath(os.path.join(root, file), 
+            ziph.write(os.path.join(root, file),
+                       os.path.relpath(os.path.join(root, file),
                                        os.path.join(path, '..')))
 
+
 class SessionViewSet(viewsets.ModelViewSet):
-#    queryset = Session.objects.all().order_by("-created_at")
     serializer_class = SessionSerializer
-    permission_classes = [IsPublic | ((IsOwner | IsAdmin | IsBackend))]
-    # permission_classes = [IsOwner]
+    permission_classes = [IsPublic | (IsOwner | IsAdmin | IsBackend)]
 
     @setup_eager_loading
     def get_queryset(self):
@@ -142,18 +134,16 @@ class SessionViewSet(viewsets.ModelViewSet):
         if user.is_authenticated and user.id == 1:
             return Session.objects.all().order_by("-created_at")
         return Session.objects.filter(Q(user__id=user.id) | Q(public=True)).order_by("-created_at")
-       
+
     @action(detail=False)
     def api_health_check(self, request):
-        
         return Response({"status": "True"})
-    
+
     @action(
         detail=True,
-        methods=["get","post"],
+        methods=["get", "post"],
     )
     def calibration(self, request, pk):
-        session_path = "/data/{}".format(pk)
         session = Session.objects.get(pk=pk)
         trial = session.trial_set.filter(name="calibration").order_by("-created_at")[0]
 
@@ -168,7 +158,7 @@ class SessionViewSet(viewsets.ModelViewSet):
             "status": "ok",
             "data": request.data,
         })
-    
+
     def retrieve(self, request, pk=None):
         session = get_object_or_404(Session.objects.all(), pk=pk)
 
@@ -177,10 +167,7 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         return Response(serializer.data)
 
-    @action(
-        detail=False,
-        methods=["get", "post"],
-    )
+    @action(detail=False, methods=["get", "post"])
     def valid(self, request):
         # Get quantity from post request. If it does exist, use it. If not, set -1 as default (e.g., return all)
         if 'quantity' not in request.data:
@@ -189,8 +176,8 @@ class SessionViewSet(viewsets.ModelViewSet):
             quantity = request.data['quantity']
 
         # Note the use of `get_queryset()` instead of `self.queryset`
-        sessions = self.get_queryset()\
-            .annotate(trial_count=Count('trial'))\
+        sessions = self.get_queryset() \
+            .annotate(trial_count=Count('trial')) \
             .filter(trial_count__gte=1, user=request.user)
         if 'subject_id' in request.data:
             subject = get_object_or_404(
@@ -239,7 +226,6 @@ class SessionViewSet(viewsets.ModelViewSet):
         serializer = SessionSerializer(session)
         return Response(serializer.data)
 
-
     ## New session GET '/new/'
     # Creates a new session, returns session id and the QR code
     @action(detail=False)
@@ -255,7 +241,7 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         img = qrcode.make("{}/sessions/{}/status/".format(settings.HOST_URL, session.id))
         print(session.id)
-        
+
         # Hack for local builds on windows
         if platform.system() == 'Windows':
             cDir = os.path.dirname(os.path.abspath(__file__))
@@ -272,11 +258,11 @@ class SessionViewSet(viewsets.ModelViewSet):
                 session.save()
 
         serializer = SessionSerializer(Session.objects.filter(id=session.id), many=True)
-                
+
         return Response(serializer.data)
-    
+
     ## New session GET '/new_subject/'
-    # Creates a new sessionm leaving metadata on previous session. Used to avoid
+    # Creates a new session leaving metadata on previous session. Used to avoid
     # re-connecting and re-calibrating cameras with every new subject.
     @action(detail=True)
     def new_subject(self, request, pk):
@@ -287,8 +273,8 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         if not user.is_authenticated:
             user = User.objects.get(id=1)
-        sessionNew.user = user        
-        
+        sessionNew.user = user
+
         # tell the new session where it can find a calibration trial
         if sessionOld.meta and 'sessionWithCalibration' in sessionOld.meta:
             sessionWithCalibration = str(sessionOld.meta['sessionWithCalibration']['id'])
@@ -297,28 +283,27 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         sessionNew.meta = {}
         sessionNew.meta["sessionWithCalibration"] = {
-                "id": sessionWithCalibration
-            }
+            "id": sessionWithCalibration
+        }
         sessionNew.save()
 
         # tell the old session to go to the new session - phones will connect to this new session
         if not sessionOld.meta:
             sessionOld.meta = {}
         sessionOld.meta["startNewSession"] = {
-                "id": str(sessionNew.id)
-            }
+            "id": str(sessionNew.id)
+        }
         sessionOld.save()
-        
-        serializer = SessionSerializer(Session.objects.filter(id=sessionNew.id), many=True)
-                
-        return Response(serializer.data)
 
+        serializer = SessionSerializer(Session.objects.filter(id=sessionNew.id), many=True)
+
+        return Response(serializer.data)
 
     def get_permissions(self):
         if self.action == 'status' or self.action == 'get_status':
             return [AllowAny(), ]
         return super(SessionViewSet, self).get_permissions()
-    
+
     def get_status(self, request, pk):
         session = Session.objects.get(pk=pk)
         self.check_object_permissions(self.request, session)
@@ -327,7 +312,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         trials = session.trial_set.order_by("-created_at")
         trial = None
 
-        status = "ready" # if no trials then "ready" (equivalent to trial_status = done)
+        status = "ready"  # if no trials then "ready" (equivalent to trial_status = done)
 
         # If there is at least one trial, check it's status
         if trials.count():
@@ -336,10 +321,10 @@ class SessionViewSet(viewsets.ModelViewSet):
         # if trial_status == 'done' then session ready again
         if trial and trial.status == "done":
             status = "ready"
-        
+
         # if trial_status == 'recording' then just continue and return 'recording'
         # otherwise recording is done and check processing
-        if trial and (trial.status in ["stopped","processing"]):
+        if trial and (trial.status in ["stopped", "processing"]):
             # if not all videos uploaded then the status is 'uploading'
             # if results are not ready then processing
             # otherwise it's ready again
@@ -365,35 +350,33 @@ class SessionViewSet(viewsets.ModelViewSet):
             if videos.count() > 0:
                 video_url = reverse('video-detail', kwargs={'pk': videos[0].id})
         trial_url = reverse('trial-detail', kwargs={'pk': trial.id}) if trial else None
-        
+
         # tell phones to pair with a new session
         if session.meta and "startNewSession" in session.meta:
             newSessionURL = "{}/sessions/{}/status/".format(settings.HOST_URL, session.meta['startNewSession']['id'])
         else:
             newSessionURL = None
-            
+
         if session.meta and "settings" in session.meta and "framerate" in session.meta['settings']:
             frameRate = int(session.meta['settings']['framerate'])
         else:
             frameRate = 60
-        if trial and (trial.name in {'calibration','neutral'}):
+        if trial and (trial.name in {'calibration', 'neutral'}):
             frameRate = 30
-
 
         res = {
             "status": status,
             "trial": trial_url,
             "video": video_url,
             "framerate": frameRate,
-            "newSessionURL":newSessionURL,
+            "newSessionURL": newSessionURL,
         }
 
         if "ret_session" in request.GET:
             res["session"] = SessionSerializer(session, many=False).data
-            
+
         return res
 
-     
     @action(detail=True)
     def get_presigned_url(self, request, pk):
         s3_client = boto3.client(
@@ -403,15 +386,15 @@ class SessionViewSet(viewsets.ModelViewSet):
         )
 
         key = str(uuid.uuid4()) + ".mov"
-        
+
         response = s3_client.generate_presigned_post(
-            Bucket = settings.AWS_STORAGE_BUCKET_NAME,
-            Key = key,
-            ExpiresIn = 1200 
+            Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+            Key=key,
+            ExpiresIn=1200
         )
 
         return Response(response)
-    
+
     ## Session status GET '<id>/status/'
     # if no active trial then return "ready"
     # if there is an active trial then return "recording"
@@ -427,7 +410,7 @@ class SessionViewSet(viewsets.ModelViewSet):
     @action(detail=True)
     def status(self, request, pk):
         status_dict = self.get_status(request, pk)
-            
+
         return Response(status_dict)
 
     ## Start recording POST '<id>/record/'
@@ -437,24 +420,24 @@ class SessionViewSet(viewsets.ModelViewSet):
     def record(self, request, pk):
         session = Session.objects.get(pk=pk)
 
-        name = request.GET.get("name",None)
+        name = request.GET.get("name", None)
 
         trial = Trial()
         trial.session = session
 
         name_count = Trial.objects.filter(name__startswith=name, session=session).count()
-        if (name_count > 0) and (name not in ["calibration","neutral"]):
+        if (name_count > 0) and (name not in ["calibration", "neutral"]):
             name = "{}_{}".format(name, name_count)
-        
+
         trial.name = name
         trial.save()
 
         if name == "calibration" or name == "neutral":
             time.sleep(2)
             return self.stop(request, pk)
-        
+
         serializer = TrialSerializer(trial, many=False)
-        
+
         return Response(serializer.data)
 
     @action(detail=True)
@@ -468,29 +451,28 @@ class SessionViewSet(viewsets.ModelViewSet):
         session_zip = downloadAndZipSession(pk, host=host)
 
         return FileResponse(open(session_zip, "rb"))
-    
-    
+
     @action(detail=True)
-    def get_session_permission(self, request, pk): 
+    def get_session_permission(self, request, pk):
         session = Session.objects.get(pk=pk)
 
         isSessionOwner = session.user == request.user
         isSessionPublic = session.public
         isUserAdmin = request.user.groups.filter(name='admin').exists()
-        sessionPermission = {'isOwner':isSessionOwner,
-                             'isPublic':isSessionPublic,
-                             'isAdmin':isUserAdmin}
-        
+        sessionPermission = {'isOwner': isSessionOwner,
+                             'isPublic': isSessionPublic,
+                             'isAdmin': isUserAdmin}
+
         return Response(sessionPermission)
-    
+
     @action(detail=True)
     def get_session_settings(self, request, pk):
         session = Session.objects.get(pk=pk)
-        
+
         # Check if using same setup
         if session.meta and 'sessionWithCalibration' in session.meta and 'id' in session.meta['sessionWithCalibration']:
             session = Session.objects.get(pk=session.meta['sessionWithCalibration']['id'])
-        
+
         self.check_object_permissions(self.request, session)
         serializer = SessionSerializer(session)
 
@@ -500,7 +482,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         # If there is at least one trial, check it's status
         if trials.count():
             trial = trials[0]
-        
+
         if trial and trial.video_set.count() > 0:
             maxFramerates = []
             for video in trial.video_set.all():
@@ -508,12 +490,12 @@ class SessionViewSet(viewsets.ModelViewSet):
                     maxFramerates.append(video.parameters['max_framerate'])
                 else:
                     maxFramerates = [60]
-                           
-        framerateOptions = [60,120,240]
-        frameratesAvailable = [f for f in framerateOptions if f<=min(maxFramerates)]
-        
-        settings_dict = {'framerates':frameratesAvailable}                          
-            
+
+        framerateOptions = [60, 120, 240]
+        frameratesAvailable = [f for f in framerateOptions if f <= min(maxFramerates)]
+
+        settings_dict = {'framerates': frameratesAvailable}
+
         return Response(settings_dict)
 
     @action(detail=True)
@@ -522,45 +504,45 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         if not session.meta:
             session.meta = {}
-        
+
         if "subject_id" in request.GET:
             session.meta["subject"] = {
-                "id": request.GET.get("subject_id",""),
-                "mass": request.GET.get("subject_mass",""),
-                "height": request.GET.get("subject_height",""),
-                "sex": request.GET.get("subject_sex",""),
-                "gender": request.GET.get("subject_gender",""),
-                "datasharing": request.GET.get("subject_data_sharing",""),
-                "posemodel": request.GET.get("subject_pose_model",""),
+                "id": request.GET.get("subject_id", ""),
+                "mass": request.GET.get("subject_mass", ""),
+                "height": request.GET.get("subject_height", ""),
+                "sex": request.GET.get("subject_sex", ""),
+                "gender": request.GET.get("subject_gender", ""),
+                "datasharing": request.GET.get("subject_data_sharing", ""),
+                "posemodel": request.GET.get("subject_pose_model", ""),
             }
 
         if "settings_framerate" in request.GET:
             session.meta["settings"] = {
-                "framerate": request.GET.get("settings_framerate",""),
+                "framerate": request.GET.get("settings_framerate", ""),
             }
 
         if "settings_data_sharing" in request.GET:
             if not session.meta["settings"]:
                 session.meta["settings"] = {}
-            session.meta["settings"]["datasharing"] = request.GET.get("settings_data_sharing","")
+            session.meta["settings"]["datasharing"] = request.GET.get("settings_data_sharing", "")
 
         if "settings_pose_model" in request.GET:
             if not session.meta["settings"]:
                 session.meta["settings"] = {}
-            session.meta["settings"]["posemodel"] = request.GET.get("settings_pose_model","")
-            
+            session.meta["settings"]["posemodel"] = request.GET.get("settings_pose_model", "")
+
         if "cb_square" in request.GET:
             session.meta["checkerboard"] = {
-                "square_size": request.GET.get("cb_square",""),
-                "rows": request.GET.get("cb_rows",""),
-                "cols": request.GET.get("cb_cols",""),
-                "placement": request.GET.get("cb_placement",""),
+                "square_size": request.GET.get("cb_square", ""),
+                "rows": request.GET.get("cb_rows", ""),
+                "cols": request.GET.get("cb_cols", ""),
+                "placement": request.GET.get("cb_placement", ""),
             }
-            
+
         session.save()
-    
+
         serializer = SessionSerializer(session, many=False)
-        
+
         return Response(serializer.data)
 
     @action(detail=True)
@@ -574,8 +556,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         serializer = SessionSerializer(session, many=False)
         return Response(serializer.data)
 
-
-## Stop recording POST '<id>/stop/'
+    ## Stop recording POST '<id>/stop/'
     # Changes the trial status from "recording" to "done"
     # Logic on the client side:
     # - session status changed so they start uploading videos
@@ -610,7 +591,7 @@ class SessionViewSet(viewsets.ModelViewSet):
 
         serializer = TrialSerializer(trial, many=False)
         return Response(serializer.data)
-    
+
     ## Cancel trial POST '<id>/stop/'
     # Changes the trial status from "stopped" to "error"
     # Logic on the client side:
@@ -621,7 +602,7 @@ class SessionViewSet(viewsets.ModelViewSet):
         trials = session.trial_set.order_by("-created_at")
 
         # If there is at least one trial, check it's status
-        if len(trials) >0:
+        if len(trials) > 0:
             trial = trials[0]
             trial.status = "error"
             trial.save()
@@ -635,7 +616,7 @@ class SessionViewSet(viewsets.ModelViewSet):
     def calibration_img(self, request, pk):
         session = Session.objects.get(pk=pk)
         self.check_object_permissions(self.request, session)
-        
+
         trials = session.trial_set.filter(name="calibration").order_by("-created_at")
         print(trials)
         if len(trials) == 0:
@@ -645,11 +626,11 @@ class SessionViewSet(viewsets.ModelViewSet):
                     "https://main.d2stl78iuswh3t.amplifyapp.com/images/camera-calibration.png"
                 ],
             }
-        elif not trials[0].status in ['done', 'error']: # this gets updated on the backend by app.py
+        elif not trials[0].status in ['done', 'error']:  # this gets updated on the backend by app.py
             data = {
                 "status": "processing",
                 "img": [
-#                    "https://main.d2stl78iuswh3t.amplifyapp.com/images/camera-calibration.png"
+                    #                    "https://main.d2stl78iuswh3t.amplifyapp.com/images/camera-calibration.png"
                 ],
             }
         else:
@@ -663,16 +644,16 @@ class SessionViewSet(viewsets.ModelViewSet):
                     "status": "done",
                     "img": list(sorted(imgs, key=lambda x: x.split("-")[-1])),
                 }
-            
-            else: 
-               data = {
+
+            else:
+                data = {
                     "status": "error",
                     "img": [
                     ],
                 }
-        
+
         return Response(data)
-    
+
     @action(detail=True)
     def neutral_img(self, request, pk):
         session = Session.objects.get(pk=pk)
@@ -686,11 +667,11 @@ class SessionViewSet(viewsets.ModelViewSet):
                     "https://main.d2stl78iuswh3t.amplifyapp.com/images/neutral_pose.png",
                 ],
             }
-        elif not trials[0].status in ['done', 'error']: # this gets updated on the backend by app.py
+        elif not trials[0].status in ['done', 'error']:  # this gets updated on the backend by app.py
             data = {
                 "status": "processing",
                 "img": [
-#                    "https://main.d2stl78iuswh3t.amplifyapp.com/images/camera-calibration.png"
+                    #                    "https://main.d2stl78iuswh3t.amplifyapp.com/images/camera-calibration.png"
                 ],
             }
         else:
@@ -704,16 +685,15 @@ class SessionViewSet(viewsets.ModelViewSet):
                     "status": "done",
                     "img": imgs
                 }
-            else: 
-               data = {
+            else:
+                data = {
                     "status": "error",
                     "img": [
                     ],
                 }
-                
-        
+
         return Response(data)
-    
+
 
 ## Processing machine:
 # A worker asks whether there is any trial to process
@@ -724,7 +704,7 @@ class TrialViewSet(viewsets.ModelViewSet):
     serializer_class = TrialSerializer
 
     permission_classes = [IsPublic | ((IsOwner | IsAdmin | IsBackend))]
-    
+
     @action(detail=False)
     def dequeue(self, request):
         ip = get_client_ip(request)
@@ -733,22 +713,23 @@ class TrialViewSet(viewsets.ModelViewSet):
 
         # find trials with some videos not uploaded
         not_uploaded = Video.objects.filter(video='',
-                                            updated_at__gte=datetime.now() + timedelta(minutes=-15)).values_list("trial__id", flat=True)
+                                            updated_at__gte=datetime.now() + timedelta(minutes=-15)).values_list(
+            "trial__id", flat=True)
 
         print(not_uploaded)
 
         uploaded_trials = Trial.objects.exclude(id__in=not_uploaded)
-#        uploaded_trials = Trial.objects.all()
+        #        uploaded_trials = Trial.objects.all()
 
         # Priority for 'calibration' and 'neutral'
         trials = uploaded_trials.filter(status="stopped",
-                                      name__in=["calibration","neutral"],
-                                      result=None)
-        
+                                        name__in=["calibration", "neutral"],
+                                        result=None)
+
         if trials.count() == 0 and workerType != 'calibration':
             trials = uploaded_trials.filter(status="stopped",
-                                      result=None)
-        
+                                            result=None)
+
         if trials.count() == 0:
             raise Http404
 
@@ -762,9 +743,9 @@ class TrialViewSet(viewsets.ModelViewSet):
             session = Session.objects.get(id=trial.session.id)
             session.server = ip
             session.save()
-            
+
         serializer = TrialSerializer(trial, many=False)
-        
+
         return Response(serializer.data)
 
     @action(detail=True, methods=['post'])
@@ -821,8 +802,6 @@ class TrialViewSet(viewsets.ModelViewSet):
         return Response(serializer.data)
 
 
-
-
 ## Upload a video:
 # Input: video and phone_id
 # Logic: Find the Video model within this session with
@@ -832,7 +811,7 @@ class VideoViewSet(viewsets.ModelViewSet):
     serializer_class = VideoSerializer
 
     permission_classes = [AllowPublicCreate | ((IsOwner | IsAdmin | IsBackend))]
-    
+
     def perform_update(self, serializer):
         if ("video_url" in serializer.validated_data) and (serializer.validated_data["video_url"]):
             serializer.validated_data["video"] = serializer.validated_data["video_url"]
@@ -909,7 +888,6 @@ class SubjectViewSet(viewsets.ModelViewSet):
         subject.delete()
         return Response({})
 
-
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)
 
@@ -919,8 +897,8 @@ class UserViewSet(viewsets.ModelViewSet):
     serializer_class = UserSerializer
 
     permission_classes = [IsAdmin]
-    
-    
+
+
 class UserCreate(APIView):
     """ 
     Creates the user. 
@@ -939,6 +917,7 @@ class UserCreate(APIView):
 
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+
 class CustomAuthToken(ObtainAuthToken):
 
     def post(self, request, *args, **kwargs):
@@ -952,57 +931,55 @@ class CustomAuthToken(ObtainAuthToken):
         user.otp_verified = False
         user.save()
         login(request, user)
-        
+
         return Response({
             'token': token.key,
             'user_id': user.id,
         })
 
-from django.core.mail import send_mail
-from django.conf import settings
-from django.core.mail import EmailMessage
-from django.template.loader import render_to_string
-import traceback
 
 class ResetPasswordView(APIView):
     permission_classes = [AllowAny]
     authentication_classes = []
 
     def post(self, request, format='json'):
-        error_message = "success"
-        serializer = ResetPasswordSerializer(data=request.data,
-                                        context={'request': request})
-        serializer.is_valid(raise_exception=True)
-        email = serializer.validated_data['email']
+        try:
+            error_message = "success"
+            serializer = ResetPasswordSerializer(data=request.data,
+                                                 context={'request': request})
+            serializer.is_valid(raise_exception=True)
+            email = serializer.validated_data['email']
 
-        host = request.data['host']
+            host = request.data['host']
 
-        # Check if there is already an existing token
-        # associated to this email and remove it.
-        objects = ResetPassword.objects.filter(email=email)
-        for object in objects:
-            object.delete()
+            # Check if there is already an existing token
+            # associated to this email and remove it.
+            objects = ResetPassword.objects.filter(email=email)
+            for object in objects:
+                object.delete()
 
-        # Generate a new token for this email.
-        ResetPassword.objects.create(
-            email=email
-        )
+            # Generate a new token for this email.
+            ResetPassword.objects.create(
+                email=email
+            )
 
-        token = get_object_or_404(ResetPassword, email__exact=email).id
-        username = get_object_or_404(User, email__exact=email).username
+            token = get_object_or_404(ResetPassword, email__exact=email).id
+            username = get_object_or_404(User, email__exact=email).username
 
-        reset_password_email_subject = 'Opencap - Forgot Username or Password'
+            reset_password_email_subject = 'Opencap - Forgot Username or Password'
 
-        link = host + '/new-password/' + str(token)
+            link = host + '/new-password/' + str(token)
 
-        logo_link = settings.LOGO_LINK
-        
-        email_body_html = render_to_string('email/reset_password_email.html')
-        email_body_html = email_body_html % (logo_link, username, link, link, str(token))
-        
-        email = EmailMessage(reset_password_email_subject, email_body_html, to=[email])
-        email.content_subtype = "html"
-        email.send()
+            logo_link = settings.LOGO_LINK
+
+            email_body_html = render_to_string('email/reset_password_email.html')
+            email_body_html = email_body_html % (logo_link, username, link, link, str(token))
+
+            email = EmailMessage(reset_password_email_subject, email_body_html, to=[email])
+            email.content_subtype = "html"
+            email.send()
+        except Http404:
+            error_message = 'Sorry, we couldn\'t find an account associated with that email. '
 
         return Response({
             'message': error_message
@@ -1016,7 +993,7 @@ class NewPasswordView(APIView):
         error_message = "Success"
 
         serializer = NewPasswordSerializer(data=request.data,
-                                        context={'request': request})
+                                           context={'request': request})
         serializer.is_valid(raise_exception=True)
         new_password = serializer.validated_data['password']
         token = serializer.validated_data['token']
@@ -1054,7 +1031,7 @@ class NewPasswordView(APIView):
             # If token exists, and it has not expired, set new password.
             user.set_password(new_password)
             user.save()
-                
+
             # Remove the token.
             objects = ResetPassword.objects.filter(email=email)
             for object in objects:
@@ -1066,26 +1043,10 @@ class NewPasswordView(APIView):
         })
 
 
-
-
-from functools import partial
-from django_otp.forms import OTPTokenForm
-
-from django.contrib.auth.decorators import login_required
-from django.views.decorators.csrf import csrf_exempt
-
-from rest_framework.authentication import TokenAuthentication
-
-from rest_framework.decorators import api_view, renderer_classes
-from rest_framework.renderers import JSONRenderer, TemplateHTMLRenderer
-
-from rest_framework import status
-
 @api_view(('POST',))
 @renderer_classes((TemplateHTMLRenderer, JSONRenderer))
 @csrf_exempt
 def verify(request):
-
     device = request.user.emaildevice_set.all()[0]
     data = json.loads(request.body.decode('utf-8'))
     verified = device.verify_token(data["otp_token"])


### PR DESCRIPTION
Before, some errors were not properly captured and the messages returned to the viewer were cryptic (e.g., Error(s) occurred: [Object object]). Now every error is captured and returns a meaningful message.

This has to be merged with stanfordnmbl/opencap-viewer/pull/88.

**Note**: This touches almost EVERY function in the views.py file, so we have to thoroughly test everything before merging to prod.