### PR TITLE
adding try catch to prevent download failure when missing results

### DIFF
--- a/mcserver/zipsession_v2.py
+++ b/mcserver/zipsession_v2.py
@@ -78,9 +78,16 @@ class SessionDirectoryConstructor:
                 videos_dir, f"Cam{idx}", "InputMedia", trial.formated_name
             )
             os.makedirs(video_root, exist_ok=True)
-            self.download_file_from_s3(
-                video.video, os.path.join(video_root, f"{trial.formated_name}.mov")
-            )
+            try:
+                self.download_file_from_s3(
+                    video.video, os.path.join(video_root, f"{trial.formated_name}.mov")
+                )
+            except:
+                if os.path.exists(os.path.join(video_root, f"{trial.formated_name}.mov")):
+                    os.remove(os.path.join(video_root, f"{trial.formated_name}.mov"))
+                if not os.listdir(video_root):
+                    os.rmdir(video_root)
+                pass
             mapping_cam_device[str(video.device_id).replace('-', '').upper()] = idx
 
         mapping_cam_device_path = os.path.join(videos_dir, 'mappingCamDevice.pickle')

--- a/mcserver/zipsession_v2.py
+++ b/mcserver/zipsession_v2.py
@@ -231,23 +231,32 @@ class SessionDirectoryConstructor:
         
         calibration_trial = Trial.get_calibration_obj_or_none(object_id)
         if calibration_trial:
-            self.collect_camera_calibration_files(calibration_trial)
-            self.collect_calibration_images_files(calibration_trial)
+            try:
+                self.collect_camera_calibration_files(calibration_trial)
+                self.collect_calibration_images_files(calibration_trial)
+            except:
+                pass
 
         neutral_and_dynamic_trials = Trial.objects.filter(
             session_id=object_id
         ).exclude(name="calibration")
         for trial in neutral_and_dynamic_trials:
-            self.collect_video_files(trial)
-            self.collect_sync_video_files(trial)
-            self.collect_marker_data_files(trial)
-            self.collect_pose_pickle_files(trial)
-            self.collect_kinematics_files(trial)
+            try:
+                self.collect_video_files(trial)
+                self.collect_sync_video_files(trial)
+                self.collect_marker_data_files(trial)
+                self.collect_pose_pickle_files(trial)
+                self.collect_kinematics_files(trial)
+            except Exception:
+                continue  # Move on to the next trial            
         
         neutral_trial = Trial.get_neutral_obj_or_none(object_id)
         if neutral_trial:
-            self.collect_opensim_model_files(neutral_trial)
-            self.collect_docs(neutral_trial)
+            try:
+                self.collect_opensim_model_files(neutral_trial)
+                self.collect_docs(neutral_trial)
+            except:
+                pass
 
         return session_dir_path
 

--- a/mcserver/zipsession_v2.py
+++ b/mcserver/zipsession_v2.py
@@ -233,6 +233,9 @@ class SessionDirectoryConstructor:
         if calibration_trial:
             try:
                 self.collect_camera_calibration_files(calibration_trial)
+            except:
+                pass
+            try:
                 self.collect_calibration_images_files(calibration_trial)
             except:
                 pass
@@ -243,17 +246,32 @@ class SessionDirectoryConstructor:
         for trial in neutral_and_dynamic_trials:
             try:
                 self.collect_video_files(trial)
+            except Exception:
+                pass
+            try:
                 self.collect_sync_video_files(trial)
+            except Exception:
+                pass
+            try:
                 self.collect_marker_data_files(trial)
+            except Exception:
+                pass
+            try:
                 self.collect_pose_pickle_files(trial)
+            except Exception:
+                pass
+            try:
                 self.collect_kinematics_files(trial)
             except Exception:
-                continue  # Move on to the next trial            
+                pass        
         
         neutral_trial = Trial.get_neutral_obj_or_none(object_id)
         if neutral_trial:
             try:
                 self.collect_opensim_model_files(neutral_trial)
+            except:
+                pass
+            try:
                 self.collect_docs(neutral_trial)
             except:
                 pass


### PR DESCRIPTION
Download is failing when the API is trying to download files from S3 that are missing. This might happen for instance for a trial for which video upload failed. This PR adds try except statements, such that download proceeds even if some stuff are missing. I tested on dev after adding a trial with missing videos to a session. Failed before the fix and worked after the fix. FYI the issue happened 693 times...Pushing to `main `here, because there is a bunch of things on `dev`. Will test on `main` after we merge.