### PR TITLE
dev: don't get client hostname from server side

### DIFF
--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -1455,7 +1455,6 @@ class TrialViewSet(viewsets.ModelViewSet):
     def dequeue(self, request):
         try:
             ip = get_client_ip(request)
-            hostname = get_client_hostname(request)
 
             workerType = self.request.query_params.get('workerType')
 


### PR DESCRIPTION
@AlbertoCasasOrtiz removing the call to get the client hostname from the server side. looks like it's easier to get the docker container ID from the client side, so working on that in opencap-core app