### PR TITLE
Mapping Man and Woman in sex to Male and Female. Fixed Intersext.

### DIFF
--- a/mcserver/models.py
+++ b/mcserver/models.py
@@ -290,9 +290,9 @@ class Subject(models.Model):
         ('prefer-not-respond', 'Prefer Not to Respond'),
     )
     SEX_AT_BIRTH_CHOICES = (
-        ('woman', 'Woman'),
-        ('man', 'Man'),
-        ('intersect', 'Intersect'),
+        ('woman', 'Female'),
+        ('man', 'Male'),
+        ('intersect', 'Intersex'),
         ('not-listed', 'Not Listed'),
         ('prefer-not-respond', 'Prefer Not to Respond'),
     )


### PR DESCRIPTION
Mapping choices to Female, Male and Intersex.

This way, although in the database the values are shown as Woman, Man and Intersect, every time it is retrieved the value is mapped into Male, Female and Intersex. This way frontend functions retrieving it would have the correct values.

Changing it in the database would imply to modify every row in which it is present, which should be addressed carefully.