### PR TITLE
Mono dequeue

### DIFF
--- a/mcserver/settings.py
+++ b/mcserver/settings.py
@@ -25,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'iw8ctf3)6e-6e#$&eoou-sqawdm4p(1+*#8tsdqy+6+tx=nlt$'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("DEBUG", default=False, cast=bool)
+DEBUG = config("DEBUG", default=True, cast=bool)
 
 HOST = config("HOST", "127.0.0.1")
 PROTOCOL = config("PROTOCOL", "http")

--- a/mcserver/settings.py
+++ b/mcserver/settings.py
@@ -25,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'iw8ctf3)6e-6e#$&eoou-sqawdm4p(1+*#8tsdqy+6+tx=nlt$'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = config("DEBUG", default=True, cast=bool)
+DEBUG = config("DEBUG", default=False, cast=bool)
 
 HOST = config("HOST", "127.0.0.1")
 PROTOCOL = config("PROTOCOL", "http")

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -233,11 +233,11 @@ class SessionViewSet(viewsets.ModelViewSet):
 
             # Nothing in calibration - assume mono
             # In future, we want to set a metadata parameter for isMono - this is a hack to allow us to collect data
-            if 'sessionWithCalibration' not in (session.meta or {}) and session.trial_set.filter(name="calibration").count() == 0:
-                return Response({
-                'error_message': error_message,
-                'data': 1
-                })
+            #if 'sessionWithCalibration' not in (session.meta or {}) and session.trial_set.filter(name="calibration").count() == 0:
+            #    return Response({
+            #    'error_message': error_message,
+            #    'data': 1
+            #    })
 
             # Check if there is a calibration trial. If not, it must be in a parent session.
             loop_counter = 0

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -1465,10 +1465,13 @@ class TrialViewSet(viewsets.ModelViewSet):
             # find trials with some videos not uploaded
             not_uploaded = Video.objects.filter(video='',
                                                 updated_at__gte=datetime.now() + timedelta(minutes=-15)).values_list("trial__id", flat=True)
+            
+            # Trials that have only one video
+            only_one_video = Trial.objects.annotate(video_count=Count('video')).filter(video_count=1).values_list("id", flat=True)
 
-            print(not_uploaded)
+            # Exclude both: trials with not-uploaded videos and trials with only one video
+            uploaded_trials = Trial.objects.exclude(id__in=not_uploaded).exclude(id__in=only_one_video)
 
-            uploaded_trials = Trial.objects.exclude(id__in=not_uploaded)
     #       uploaded_trials = Trial.objects.all()
 
             if workerType != 'dynamic':

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -1469,17 +1469,17 @@ class TrialViewSet(viewsets.ModelViewSet):
             ip = get_client_ip(request)
 
             workerType = self.request.query_params.get('workerType', 'all')
-            isMono = self.request.query_params.get('isMono', 'false')
+            isMono = self.request.query_params.get('isMono', 'False')
 
             # find trials with some videos not uploaded
             not_uploaded = Video.objects.filter(video='',
                                                 updated_at__gte=datetime.now() + timedelta(minutes=-15)).values_list("trial__id", flat=True)
             
             # Trials that have only one video
-            only_one_video = Trial.objects.annotate(video_count=Count('video')).filter(video_count=1).values_list("trial__id", flat=True)
+            only_one_video = Trial.objects.annotate(video_count=Count('video')).filter(video_count=1).values_list("id", flat=True)
 
             # Exclude both: trials with not-uploaded videos and trials with only one video
-            if isMono == 'true':
+            if isMono == 'True':
                 uploaded_trials = Trial.objects.exclude(id__in=not_uploaded).filter(id__in=only_one_video)
             else:
                 # Exclude trials with not-uploaded videos and only 1 video

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -231,6 +231,14 @@ class SessionViewSet(viewsets.ModelViewSet):
             calibration_trials = session.trial_set.filter(name="calibration")
             last_calibration_trial_num_videos = 0
 
+            # Nothing in calibration - assume mono
+            # In future, we want to set a metadata parameter for isMono - this is a hack to allow us to collect data
+            if 'sessionWithCalibration' not in session.meta and session.trial_set.filter(name="calibration").count() == 0:
+                return Response({
+                'error_message': error_message,
+                'data': 1
+                })
+
             # Check if there is a calibration trial. If not, it must be in a parent session.
             loop_counter = 0
             while not calibration_trials and session.meta.get('sessionWithCalibration') and loop_counter < 100:

--- a/mcserver/views.py
+++ b/mcserver/views.py
@@ -233,7 +233,7 @@ class SessionViewSet(viewsets.ModelViewSet):
 
             # Nothing in calibration - assume mono
             # In future, we want to set a metadata parameter for isMono - this is a hack to allow us to collect data
-            if 'sessionWithCalibration' not in session.meta and session.trial_set.filter(name="calibration").count() == 0:
+            if 'sessionWithCalibration' not in (session.meta or {}) and session.trial_set.filter(name="calibration").count() == 0:
                 return Response({
                 'error_message': error_message,
                 'data': 1


### PR DESCRIPTION
This adds an optional parameter to the dequeue endpoint for trials to be processed by our opencap monocular pipeline (1 video). The default endpoint, called by app.py in opencap-core, will continue to function the same. As configured, there will be separate backend worker machines processing 2+ camera trials (the existing opencap-core pipeline) and those processing opencap mono trials (we'll host @ Utah). 

1) When we actually deploy this, we will have a metadata parameter, set at the QR code stage of the viewer, where someone selects if they're using monocular or the standard multicamera approach. Right now it is autodetecting, but we will fix this once the viewer workflow is complete.
2) I finished the implementation of (but did not test) the idea of a 'priority' group. This way we can speed up processing for non-admin users (e.g., neuromuscular clinic). The 'priority' group label exists in the database, we just haven't used it. This is good for a number of reasons, one of which is it leaves admin demos truly priority, and gives us the ability to securely give people priority processing for key data collection events.
3) I have tested that this does not affect the normal function of the dequeue function, so it is safe to merge 

