### PR TITLE
update github actions deployment

### DIFF
--- a/.github/workflows/ecr-dev.yml
+++ b/.github/workflows/ecr-dev.yml
@@ -28,6 +28,7 @@ on:
   push:
     branches:
       - dev
+  workflow_dispatch:
 
 name: DEV ECS build & deployment
 

--- a/.github/workflows/ecr.yml
+++ b/.github/workflows/ecr.yml
@@ -29,6 +29,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+    branches:
+      - main
 
 name: PRODUCTION ECS build & deployment
 


### PR DESCRIPTION
should help you all be able to deploy any feature branch to dev, reducing need to undo/redo commits on dev branch. note this is going to main branch so it shows up in the Actions tab.
- adds a button for dev deployment to force deploy from any branch
- limits the button for force deploying main to the main branch