### PR TITLE
`FileNotFoundError` retry: don't throw at the end of retries

### DIFF
--- a/mcserver/zipsession_v2.py
+++ b/mcserver/zipsession_v2.py
@@ -336,9 +336,16 @@ def rmtree_with_retry(path, max_retries=5, backoff=0.1):
             shutil.rmtree(path)
             return
         
-        except (FileNotFoundError, PermissionError, OSError) as e:
+        except (PermissionError, OSError) as e:
             if attempt == max_retries - 1:
                 raise
+            time.sleep(backoff * (2**attempt))
+
+        except FileNotFoundError as e:
+            # In case we've made it here, we've made a best effort to delete
+            # and it's likely gone.
+            if attempt == max_retries - 1:
+                return
             time.sleep(backoff * (2**attempt))
 
 def zipdir_contents_with_retry(dir_path, zip_path, max_retries=5, backoff=0.1):


### PR DESCRIPTION
@AlbertoCasasOrtiz 

Related to #264.

Previous PR seems to have reduced many of the different errors on Sentry, but may have funneled the issue to a new one. This PR eases throwing an error for `FileNotFoundError` when `max_retries` has been reached. We'll assume that the folder has been given enough attempts to be deleted and it's unlikely the folder will be there.