### PR TITLE
patch rmtree_with_retry

### DIFF
--- a/mcserver/zipsession_v2.py
+++ b/mcserver/zipsession_v2.py
@@ -335,17 +335,17 @@ def rmtree_with_retry(path, max_retries=5, backoff=0.1):
         try:
             shutil.rmtree(path)
             return
-        
-        except (PermissionError, OSError) as e:
-            if attempt == max_retries - 1:
-                raise
-            time.sleep(backoff * (2**attempt))
 
         except FileNotFoundError as e:
             # In case we've made it here, we've made a best effort to delete
             # and it's likely gone.
             if attempt == max_retries - 1:
                 return
+            time.sleep(backoff * (2**attempt))
+
+        except (PermissionError, OSError) as e:
+            if attempt == max_retries - 1:
+                raise
             time.sleep(backoff * (2**attempt))
 
 def zipdir_contents_with_retry(dir_path, zip_path, max_retries=5, backoff=0.1):


### PR DESCRIPTION
@AlbertoCasasOrtiz I saw this didn't quite work on sentry (`FileNotFoundError` is still being raised at the end of retries). I missed that `FileNotFoundError` inherits from `OSError` (https://docs.python.org/3/library/exceptions.html#os-exceptions), so need to catch it first.